### PR TITLE
Add fastlag module and optimize lag selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,29 @@ jobs:
         with:
           python-version: "3.13"
           cache: "pip"
+
+      - name: Cache venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+
+      - name: Set up venv
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: python -m venv .venv
+
+      - name: Install uv
+        run: pipx install uv
+
       - name: Install deps
         run: |
+          source .venv/bin/activate
           python -m pip install --upgrade pip
-          pip install -r requirements.txt black==24.10.0 mypy pandas-stubs types-requests pyarrow-stubs types-html5lib lxml-stubs scipy-stubs types-seaborn types-PyYAML
+          uv pip install -r requirements.txt black==24.10.0 mypy pandas-stubs types-requests pyarrow-stubs types-html5lib lxml-stubs scipy-stubs types-seaborn types-PyYAML      
+
       - name: mypy
         run: mypy ./CandleNet/
+
       - name: black (check)
         run: black --check ./CandleNet/
 
@@ -28,17 +45,32 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-python@v5
-          with:
-            python-version: "3.13"
-            cache: "pip"
-        - name: Install Dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
 
-        - name: Run CI Tests
-          run: |
-              PYTHONPATH=. python -m pytest ./tests/ --maxfail=3 -k "not web_access and not slow"
-          
+      - name: Cache venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+
+      - name: Set up venv
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: python -m venv .venv
+
+      - name: Install uv
+        run: pipx install uv
+
+      - name: Install Dependencies
+        run: |
+          source .venv/bin/activate
+          pip install --upgrade pip
+          uv pip install -r requirements.txt
+
+      - name: Run CI Tests
+        run: |
+          source .venv/bin/activate
+          PYTHONPATH=. pytest ./tests/ --maxfail=5 -k "not web_access and not slow"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,14 @@ jobs:
           uv pip install -r requirements.txt black==24.10.0 mypy pandas-stubs types-requests pyarrow-stubs types-html5lib lxml-stubs scipy-stubs types-seaborn types-PyYAML      
 
       - name: mypy
-        run: mypy ./CandleNet/
+        run: |
+          source .venv/bin/activate
+          mypy ./CandleNet/
 
       - name: black (check)
-        run: black --check ./CandleNet/
+        run: |
+          source .venv/bin/activate
+          black --check ./CandleNet/
 
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,14 @@ jobs:
           cache: "pip"
 
       - name: Cache venv
+        id: lint-venv-cache
         uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
 
       - name: Set up venv
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.lint-venv-cache.outputs.cache-hit != 'true'
         run: python -m venv .venv
 
       - name: Install uv
@@ -56,13 +57,14 @@ jobs:
           cache: "pip"
 
       - name: Cache venv
+        id: test-venv-cache
         uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
 
       - name: Set up venv
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.test-venv-cache.outputs.cache-hit != 'true'
         run: python -m venv .venv
 
       - name: Install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        id: lint-python
         with:
           python-version: "3.13"
           cache: "pip"
@@ -21,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          key: venv-${{ runner.os }}-py${{ steps.lint-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
 
       - name: Set up venv
         if: steps.lint-venv-cache.outputs.cache-hit != 'true'
@@ -52,6 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        id: test-python
         with:
           python-version: "3.13"
           cache: "pip"
@@ -61,7 +63,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+          key: venv-${{ runner.os }}-py${{ steps.test-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
 
       - name: Set up venv
         if: steps.test-venv-cache.outputs.cache-hit != 'true'

--- a/CandleNet/autoreg/fastlag/__init__.py
+++ b/CandleNet/autoreg/fastlag/__init__.py
@@ -1,0 +1,3 @@
+from .select import vectorized_select_lags
+
+__all__ = ["vectorized_select_lags"]

--- a/CandleNet/autoreg/fastlag/engine.py
+++ b/CandleNet/autoreg/fastlag/engine.py
@@ -1,0 +1,75 @@
+import numpy as np
+from numba import njit  # type: ignore[import-untyped]
+
+
+@njit(cache=True, fastmath=True)
+def _ols_hac_beta_t_vectorized(
+    y: np.ndarray,
+    max_lag: int,
+    L: int,
+):
+
+    n = y.shape[0]
+    beta = np.empty(max_lag, dtype=np.float64)
+    tval = np.empty(max_lag, dtype=np.float64)
+    nobs = np.empty(max_lag, dtype=np.int64)
+
+    for k in range(1, max_lag + 1):
+        N = n - k
+        nobs[k - 1] = N
+        if N < 10:
+            continue
+
+        x = y[:N]
+        yy = y[k:n]
+
+        xb, yb = 0.0, 0.0
+        for i in range(N):
+            xb += x[i]
+            yb += yy[i]
+
+        xb /= N
+        yb /= N
+
+        Sxx, Sxy = 0.0, 0.0
+        for i in range(N):
+            dx = x[i] - xb
+            dy = yy[i] - yb
+            Sxx += dx * dx
+            Sxy += dx * dy
+
+        if Sxx <= 0.0:
+            continue
+
+        b = Sxy / Sxx
+
+        s = np.empty(N, dtype=np.float64)
+        for i in range(N):
+            dx = x[i] - xb
+            dy = yy[i] - yb
+            u = dy - b * dx
+            s[i] = dx * u
+
+        gamma0 = 0.0
+        for i in range(N):
+            gamma0 += s[i] * s[i]
+        gamma0 /= N
+        omega = gamma0
+
+        L_eff = L if L < (N - 1) else (N - 1)
+        for l in range(1, L_eff + 1):  # noqa[E741]
+            w = 1.0 - l / (L + 1.0)
+            g = 0.0
+            M = N - l
+            for i in range(M):
+                g += s[i + l] * s[i]
+            g /= N
+            omega += 2.0 * w * g
+
+        var_b = (N * omega) / (Sxx * Sxx)
+        t = b / np.sqrt(var_b) if var_b > 0.0 else np.nan
+
+        beta[k - 1] = b
+        tval[k - 1] = t
+
+    return beta, tval, nobs

--- a/CandleNet/autoreg/fastlag/engine.py
+++ b/CandleNet/autoreg/fastlag/engine.py
@@ -10,15 +10,16 @@ def _ols_hac_beta_t_vectorized(
 ):
 
     n = y.shape[0]
-    beta = np.empty(max_lag, dtype=np.float64)
-    tval = np.empty(max_lag, dtype=np.float64)
-    nobs = np.empty(max_lag, dtype=np.int64)
+    beta = np.full(max_lag, np.nan, dtype=np.float64)
+    tval = np.full(max_lag, np.nan, dtype=np.float64)
+    nobs = np.zeros(max_lag, dtype=np.int64)
 
     for k in range(1, max_lag + 1):
         N = n - k
         nobs[k - 1] = N
         if N < 10:
-            continue
+            beta[k - 1] = np.nan
+            tval[k - 1] = np.nan
 
         x = y[:N]
         yy = y[k:n]
@@ -39,7 +40,8 @@ def _ols_hac_beta_t_vectorized(
             Sxy += dx * dy
 
         if Sxx <= 0.0:
-            continue
+            beta[k - 1] = np.nan
+            tval[k - 1] = np.nan
 
         b = Sxy / Sxx
 

--- a/CandleNet/autoreg/fastlag/select.py
+++ b/CandleNet/autoreg/fastlag/select.py
@@ -1,0 +1,363 @@
+from CandleNet import lag_config
+import numpy as np
+import pandas as pd
+from scipy.stats import norm
+from statsmodels.stats.multitest import multipletests  # type: ignore[import-untyped]
+from .engine import _ols_hac_beta_t_vectorized
+from CandleNet import LagConfig
+from typing import Any, Generator, Literal, Optional, Tuple
+
+
+def _is_int_like(x: Any) -> bool:
+    if not hasattr(x, "__int__"):
+        return False
+
+    return x - int(x) <= 1e-8
+
+
+def _resolve_lag_cfg(params: LagConfig, n: int) -> dict:
+    """
+    Resolve a LagConfig mapping into concrete numeric parameters used for lag testing and bootstrapping.
+
+    This converts potentially symbolic or "auto" entries in `params` into integer values appropriate for
+    a series of length `n`, applying sensible bounds and heuristics where needed.
+
+    Parameters:
+        params (LagConfig): Configuration mapping containing keys:
+            - "maxLag": maximum lag to consider (may be numeric or "auto"-like value).
+            - "hacBandwidth": Newey–West/HAC bandwidth or "auto".
+            - "blockLen": circular block bootstrap block length or "auto".
+            - "bootstrapSamples": number of bootstrap replicates or "auto".
+            - "maxLagsSelected": cap on number of selected lags or "auto".
+            - "minBootstrapSamples", "minLagsSelected": minimums used when resolving "auto".
+        n (int): Length of the time series; used to clamp and derive data-dependent defaults.
+
+    Returns:
+        dict: A mapping with integer-valued keys:
+            - "max_lag": selected max lag (clamped to at least 1 and at most n-2).
+            - "bandwidth": resolved HAC bandwidth as an int.
+            - "block_len": resolved block length for CBB as an int.
+            - "B": number of bootstrap replicates as an int.
+            - "max_selected": maximum number of lags to retain as an int (>= 0).
+    """
+    max_lag = int(params["maxLag"])
+    max_lag = max(1, min(max_lag, n - 2))
+
+    # bandwidth
+    bw = params["hacBandwidth"]
+    if isinstance(bw, str) and bw == "auto":
+        bw = _auto_nw_bandwidth(n)
+
+    # block length
+    bl = params["blockLen"]
+    if isinstance(bl, str) and bl == "auto":
+        bl = _auto_block_len(n)
+
+    # bootstrap samples
+    B = params["bootstrapSamples"]
+    if isinstance(B, str) and B == "auto":
+        # heuristic: proportional to tested lags, capped
+        B = max(params["minBootstrapSamples"], min(300, 20 * max_lag))
+
+    # max lags selected
+    msel_cfg = params["maxLagsSelected"]
+    if isinstance(msel_cfg, str) and msel_cfg == "auto":
+        msel = max(params["minLagsSelected"], min(5, max_lag))
+    else:
+        msel = msel_cfg
+
+    assert _is_int_like(msel) and msel >= 0, (
+        f"Unsupported maxLagsSelected: {msel_cfg}. "
+        f"Must be a non-negative integer or 'auto'."
+    )
+
+    return {
+        "max_lag": max_lag,
+        "bandwidth": int(bw),
+        "block_len": int(bl),
+        "B": int(B),
+        "max_selected": int(msel),
+    }
+
+
+def _auto_nw_bandwidth(n: int) -> int:
+    # Andrews(1991)/Newey-West style small-sample bandwidth; keep it tiny for daily data
+    # 4 * (n/100)^(2/9), at least 1
+    """
+    Compute a small-sample Newey–West (Andrews-style) bandwidth heuristic.
+
+    Parameters:
+        n (int): Sample size (number of observations) used to derive the bandwidth.
+
+    Returns:
+        bw (int): Bandwidth for Newey–West/HAC estimation, computed as max(1, round(4 * (n/100)^(2/9))).
+    """
+    bw = round(4.0 * (max(n, 2) / 100.0) ** (2.0 / 9.0))
+    return max(bw, 1)
+
+
+def _infer_block_len(n: int) -> int:
+    """Heuristic: l = max(5, floor(n**(1/3)))."""
+    return max(5, int(np.floor(n ** (1 / 3))))
+
+
+def _auto_block_len(n: int) -> int:
+    """
+    Select an automatic block length for block bootstrap based on the series length.
+
+    Parameters:
+        n (int): Number of observations in the time series.
+
+    Returns:
+        block_len (int): Recommended block length, equal to the greater of 5 and the floor of the cube root of `n`.
+    """
+    return max(5, int(n ** (1 / 3)))
+
+
+def cbb_indices(
+    n: int,
+    B: int,
+    block_len: int | Literal["auto"] = "auto",
+    rng: Optional[np.random.Generator] = None,
+) -> Generator[np.ndarray, None, None]:
+    """
+    Yield index arrays for circular block bootstrap resampling of a length-n series.
+
+    Parameters:
+        n (int): Length of the original time series.
+        B (int): Number of bootstrap replicates to generate.
+        block_len (int or "auto"): Block length to use for the circular blocks. If "auto",
+        a heuristic based on `n` is used.
+        rng (np.random.Generator, optional): Random number generator to sample block starting positions. If omitted,
+        a default Generator is created.
+
+    Yields:
+        np.ndarray: 1-D integer array of length `n` containing indices into the original series
+        for one bootstrap replicate.
+
+    Raises:
+        ValueError: If `n`, `B`, or resolved `block_len` is not positive.
+    """
+    if n <= 0:
+        raise ValueError("n must be positive.")
+    if B <= 0:
+        raise ValueError("B must be positive.")
+
+    if block_len == "auto":
+        block_len = _infer_block_len(n)
+    if block_len <= 0:
+        raise ValueError("block_len must be positive.")
+
+    # For very small n, cap block length
+    l = min(block_len, n)  # noqa: E741
+
+    rng = np.random.default_rng() if rng is None else rng
+
+    # Precompute starting points for blocks (0...n-1).
+    # CBB wraps modulo n, so every block is [s, s+1, ..., s+l-1] mod n.
+    n_blocks = int(np.ceil(n / l))
+
+    for _ in range(B):
+        starts = rng.integers(low=0, high=n, size=n_blocks, endpoint=False)
+        # Build blocks via broadcasting, then wrap mod n
+        offsets = np.arange(l)[None, :]
+        blocks = (starts[:, None] + offsets) % n  # shape: (n_blocks, l)
+        idx = blocks.reshape(-1)[:n]  # trim to exact length n
+        yield idx
+
+
+def cbb_sample(
+    X: np.ndarray,
+    B: int,
+    block_len: int | Literal["auto"] = "auto",
+    rng: Optional[np.random.Generator] = None,
+    return_indices: bool = False,
+) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+    """
+    Generate B circular block bootstrap (CBB) resamples of a time series, preserving joint structure across columns.
+
+    Parameters:
+        X (np.ndarray): Time-series data of shape (n,) or (n, p). 1D inputs are treated as (n, 1).
+        B (int): Number of bootstrap replicates to generate.
+        block_len (int or "auto"): Block length for the CBB. If "auto", a heuristic block length is chosen.
+        rng (np.random.Generator, optional): Random number generator to control reproducibility. If None,
+        the default global RNG is used.
+        return_indices (bool): If True, also return the index matrix used for resampling.
+
+    Returns:
+        Xb (np.ndarray): Bootstrap samples. Shape is (B, n) for 1D inputs or (B, n, p) for 2D inputs.
+        Ib (np.ndarray or None): Integer index matrix of shape (B, n) used to form each resample when
+        return_indices is True; otherwise None.
+    """
+    X = np.asarray(X)
+    if X.ndim == 1:
+        X2 = X[:, None]
+        squeeze = True
+    elif X.ndim == 2:
+        X2 = X
+        squeeze = False
+    else:
+        raise ValueError("X must be 1D or 2D (time[, features]).")
+
+    n = X2.shape[0]
+    p = X2.shape[1]
+
+    Ib = np.empty((B, n), dtype=np.int64)
+    Xb = np.empty((B, n, p), dtype=X2.dtype)
+
+    gen = cbb_indices(n=n, B=B, block_len=block_len, rng=rng)
+    for b, idx in enumerate(gen):
+        Ib[b] = idx
+        Xb[b] = X2[idx, :]
+
+    if squeeze:
+        Xb = Xb[:, :, 0]  # -> (B, n)
+
+    return (Xb, Ib) if return_indices else (Xb, None)
+
+
+def _wilson_interval(
+    successes: np.ndarray, trials: np.ndarray, conf: float = 0.95
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Vectorized Wilson score interval for binomial proportion.
+    Returns (lo, hi) arrays.
+    """
+    successes = successes.astype(float)
+    trials = trials.astype(float)
+    p_hat = np.divide(
+        successes, trials, out=np.zeros_like(successes, dtype=float), where=trials > 0
+    )
+
+    # z for two-sided
+    z = float(norm.ppf(0.5 + conf / 2.0))
+    denom = 1.0 + (z * z) / trials
+    center = p_hat + (z * z) / (2.0 * trials)
+    spread = z * np.sqrt(
+        np.divide(
+            p_hat * (1.0 - p_hat),
+            trials,
+            out=np.zeros_like(trials, dtype=float),
+            where=trials > 0,
+        )
+        + (z * z) / (4.0 * trials * trials)
+    )
+    lo = (center - spread) / denom
+    hi = (center + spread) / denom
+    # clamp to [0,1]
+    lo = np.clip(lo, 0.0, 1.0)
+    hi = np.clip(hi, 0.0, 1.0)
+    return lo, hi
+
+
+def vectorized_select_lags(y) -> list[int]:
+
+    params = lag_config()
+    _r = _resolve_lag_cfg(params, len(y))
+
+    max_lag = _r["max_lag"]
+    bandwidth = _r["bandwidth"]
+    B = _r["B"]
+    block_len = _r["block_len"]
+    max_selected = _r["max_selected"]
+
+    alpha = params["sigLevel"]
+    require_stability = params["requireStability"]
+    min_freq = params["stabilityFreq"]
+    conf = params["stabilityConfidence"]
+    early_stop = params["earlyStop"]
+    b_min = params["minBootstrapSamples"]
+    check_every = params["stabilityCheckEvery"]
+    use_fdr_end = params["selectionMethod"] == "fdrAdjusted"
+    min_selected = params["minLagsSelected"]
+    rank_topn = params["rankTopN"]
+    rng = np.random.default_rng(params["randomSeed"])
+
+    yv = y.to_numpy(dtype=np.float64).ravel()
+    n = yv.size
+    if n < 10:
+        return []
+
+    L = _auto_nw_bandwidth(n) if bandwidth == "auto" else int(bandwidth)
+
+    # base-sample
+    beta0, t0, nobs0 = _ols_hac_beta_t_vectorized(yv, max_lag, L)
+    p0 = 2.0 * norm.sf(np.abs(t0))
+
+    # bootstrap
+    Xb, _ = cbb_sample(yv, B=B, block_len=block_len, rng=rng)  # (B,n)
+    decided = np.zeros(max_lag, bool)
+    decision_b = np.full(max_lag, -1, int)
+    stable_flag = np.zeros(max_lag, bool)
+    select_counts = np.zeros(max_lag, int)
+    top_counts = np.zeros(max_lag, int)
+
+    for b in range(1, B + 1):
+        if early_stop and decided.all():
+            break
+        beta_b, t_b, _ = _ols_hac_beta_t_vectorized(
+            Xb[b - 1].astype(np.float64, copy=False), max_lag, L
+        )
+        p_b = 2.0 * norm.sf(np.abs(t_b))
+
+        m = ~decided
+        if m.any():
+            sel = (p_b[m] < alpha).astype(np.int64)
+            select_counts[m] += sel
+
+        if np.isfinite(p_b).any():
+            top = int(np.nanargmin(p_b))
+            top_counts[top] += 1
+
+        if early_stop and b >= b_min and (b % check_every == 0):
+            trials = np.where(decided, np.maximum(decision_b, 1), b).astype(np.float64)
+            lo, hi = _wilson_interval(
+                select_counts.astype(np.float64), trials, conf=conf
+            )
+            newly_stable = (~decided) & (lo >= min_freq)
+            newly_unstable = (~decided) & (hi < min_freq)
+            if newly_stable.any():
+                decided[newly_stable] = True
+                stable_flag[newly_stable] = True
+                decision_b[newly_stable] = b
+            if newly_unstable.any():
+                decided[newly_unstable] = True
+                stable_flag[newly_unstable] = False
+                decision_b[newly_unstable] = b
+
+    trials = np.where(decision_b > 0, decision_b, min(B, len(Xb))).astype(np.float64)
+    freq = select_counts / np.maximum(trials, 1.0)
+    top_freq = top_counts / B
+
+    # Final masks (mirror original)
+    if use_fdr_end:
+        reject, p_fdr, _, _ = multipletests(p0, alpha=alpha, method="fdr_bh")
+    else:
+        reject = p0 < alpha
+        p_fdr = np.full_like(p0, np.nan, dtype=np.float64)
+
+    stable = (freq >= min_freq) if require_stability else np.ones_like(freq, bool)
+    selected_mask = stable & reject if use_fdr_end else stable & (p0 < alpha)
+
+    # Fallback & caps
+    idx = np.arange(1, max_lag + 1)
+    selected_idx = idx[selected_mask]
+
+    if selected_idx.size == 0:
+        take = max(min_selected, (rank_topn or 0))
+        order = np.lexsort((-freq, p0))  # primary p asc, tie by freq desc
+        selected_idx = idx[order][:take]
+
+    if selected_idx.size < min_selected:
+        need = min_selected - selected_idx.size
+        mask_rem = np.ones(max_lag, bool)
+        mask_rem[selected_idx - 1] = False
+        order = np.lexsort((-freq[mask_rem], p0[mask_rem]))
+        add = idx[mask_rem][order][:need]
+        selected_idx = np.sort(np.concatenate([selected_idx, add]))
+
+    if selected_idx.size > max_selected:
+        order = np.lexsort((-freq[selected_idx - 1], p0[selected_idx - 1]))
+        selected_idx = selected_idx[order][:max_selected]
+
+    return np.sort(selected_idx).tolist()

--- a/CandleNet/autoreg/fastlag/select.py
+++ b/CandleNet/autoreg/fastlag/select.py
@@ -281,7 +281,7 @@ def vectorized_select_lags(y) -> list[int]:
     if n < 10:
         return []
 
-    L = _auto_nw_bandwidth(n) if bandwidth == "auto" else int(bandwidth)
+    L = int(bandwidth)
 
     # base-sample
     _, t0, _ = _ols_hac_beta_t_vectorized(yv, max_lag, L)

--- a/CandleNet/autoreg/lag_utils.py
+++ b/CandleNet/autoreg/lag_utils.py
@@ -260,6 +260,9 @@ def cbb_sample(
     else:
         raise ValueError("X must be 1D or 2D (time[, features]).")
 
+    if B <= 0:
+        raise ValueError("B must be positive.")
+
     n = X2.shape[0]
     p = X2.shape[1]
 
@@ -579,6 +582,7 @@ def fast_bootstrapped_significance(
     trials = np.where(decision_b > 0, decision_b, min(B, len(Xb))).astype(np.float64)
     freq = select_counts / np.maximum(trials, 1.0)
     top_f = top_counts / max(B, 1)
+    stable_flag = np.logical_or(stable_flag, freq >= min_freq)
 
     # --- Build the DF once (shape identical to the slow path)
     idx = pd.Index(range(1, max_lag + 1), name="lag")

--- a/CandleNet/autoreg/lag_utils.py
+++ b/CandleNet/autoreg/lag_utils.py
@@ -545,7 +545,7 @@ def fast_bootstrapped_significance(
         if early_stop and decided.all():
             break
 
-        beta_b, t_b, _ = _ols_hac_beta_t_vectorized(
+        _, t_b, _ = _ols_hac_beta_t_vectorized(
             Xb[b - 1].astype(np.float64, copy=False), max_lag, L
         )
         p_b = 2.0 * norm.sf(np.abs(t_b))

--- a/CandleNet/autoreg/lag_utils.py
+++ b/CandleNet/autoreg/lag_utils.py
@@ -6,7 +6,7 @@ import statsmodels.api as sm  # type: ignore
 from statsmodels.stats.multitest import multipletests  # type: ignore
 from scipy.stats import norm  # type: ignore
 from CandleNet.logger import Logger, LogType, OriginType, CallerType
-
+from .fastlag.engine import _ols_hac_beta_t_vectorized
 
 from CandleNet.utils import SERIES
 from CandleNet import lag_config, LagConfig
@@ -335,11 +335,11 @@ def bootstrapped_significance(
         max_lag (int): Maximum lag to evaluate (lags 1...max_lag).
         B (int): Number of bootstrap resamples to draw.
         block_len (int | "auto"): Block length for circular block bootstrap or "auto" to derive from sample size.
-        bandwidth (int | "auto"): Newey–West/HAC bandwidth to use for HAC-covariance estimation or "auto" to derive
+        bandwidth (int | "auto"): Newey-West/HAC bandwidth to use for HAC-covariance estimation or "auto" to derive
         from sample size.
         alpha (float): Significance level used when counting a lag as selected on each resample.
         rng (np.random.Generator | None): Random number generator; a default RNG is created when None.
-        use_fdr_end (bool): If True, apply Benjamini–Hochberg FDR to base-sample p-values for final reporting/selection.
+        use_fdr_end (bool): If True, apply Benjamini-Hochberg FDR to base-sample p-values for final reporting/selection.
         min_freq (float): Frequency threshold in [0,1] used to mark a lag as "stable" (freq >= min_freq).
         early_stop (bool): If True, allow early stopping of the bootstrap loop when Wilson intervals
         confidently decide lags.
@@ -418,7 +418,7 @@ def bootstrapped_significance(
             select_counts[mask] += sel
 
         # rank-based winner (for diagnostics only)
-        top = int(res_b["p"].nanargmin()) + 1  # raises ValueError if all NaN
+        top = int(np.nanargmin(res_b["p"])) + 1  # raises ValueError if all NaN
         top_rank_counts[top - 1] += 1
         # Early stopping check
         if early_stop and b >= b_min and (b % check_every == 0):
@@ -477,6 +477,126 @@ def bootstrapped_significance(
     return out.sort_values(
         ["selected", "freq", "top_freq"], ascending=[False, False, False]
     )
+
+
+def fast_bootstrapped_significance(
+    y: np.ndarray | pd.Series,
+    *,
+    max_lag: int,
+    bandwidth: int,  # pass resolved int here
+    B: int,
+    block_len: int,  # pass resolved int here
+    alpha: float,
+    use_fdr_end: bool,
+    min_freq: float,
+    early_stop: bool,
+    b_min: int,
+    check_every: int,
+    conf: float,
+    rng: np.random.Generator | None = None,
+) -> pd.DataFrame:
+    """
+    Drop-in replacement for bootstrapped_significance that uses the fast kernel.
+    Returns a DataFrame indexed by lag with columns:
+      ['p_base','reject_base_fdr','freq','stable','trials','top_freq','n','beta','t']
+    """
+    y = np.asarray(y, dtype=np.float64).ravel()
+    n = y.size
+    if n < 10:
+        # empty result with expected schema
+        idx = pd.Index(range(1, max_lag + 1), name="lag")
+        return pd.DataFrame(
+            index=idx,
+            columns=[
+                "p_base",
+                "reject_base_fdr",
+                "freq",
+                "stable",
+                "trials",
+                "top_freq",
+                "n",
+                "beta",
+                "t",
+            ],
+            dtype=float,
+        ).fillna(np.nan)
+
+    L = int(bandwidth)
+
+    # --- base sample (no pandas)
+    beta0, t0, n0 = _ols_hac_beta_t_vectorized(y, max_lag, L)
+    p0 = 2.0 * norm.sf(np.abs(t0))
+    reject_fdr = np.zeros_like(p0, dtype=bool)
+    if use_fdr_end:
+        reject_fdr, _, _, _ = multipletests(p0, alpha=alpha, method="fdr_bh")
+
+    # --- bootstrap (counts only)
+    Xb, _ = cbb_sample(y, B=B, block_len=block_len, rng=rng)  # shape (B, n)
+    select_counts = np.zeros(max_lag, dtype=np.int64)
+    top_counts = np.zeros(max_lag, dtype=np.int64)
+    decided = np.zeros(max_lag, dtype=bool)
+    decision_b = np.full(max_lag, -1, dtype=np.int64)
+    stable_flag = np.zeros(max_lag, dtype=bool)
+
+    for b in range(1, B + 1):
+        if early_stop and decided.all():
+            break
+
+        beta_b, t_b, _ = _ols_hac_beta_t_vectorized(
+            Xb[b - 1].astype(np.float64, copy=False), max_lag, L
+        )
+        p_b = 2.0 * norm.sf(np.abs(t_b))
+
+        # update counts for undecided lags
+        m = ~decided
+        if m.any():
+            sel = p_b[m] < alpha  # bool
+            select_counts[m] += sel.astype(np.int64)
+
+        # track "top p" frequency
+        if np.isfinite(p_b).any():
+            top = int(np.nanargmin(p_b))
+            top_counts[top] += 1
+
+        # early stop via Wilson CI around freq
+        if early_stop and b >= b_min and (b % check_every == 0):
+            trials = np.where(decided, np.maximum(decision_b, 1), b).astype(np.float64)
+            lo, hi = _wilson_interval(
+                select_counts.astype(np.float64), trials, conf=conf
+            )
+            newly_stable = (~decided) & (lo >= min_freq)
+            newly_unstable = (~decided) & (hi < min_freq)
+            if newly_stable.any():
+                decided[newly_stable] = True
+                stable_flag[newly_stable] = True
+                decision_b[newly_stable] = b
+            if newly_unstable.any():
+                decided[newly_unstable] = True
+                stable_flag[newly_unstable] = False
+                decision_b[newly_unstable] = b
+
+    # finalize frequency and trials
+    trials = np.where(decision_b > 0, decision_b, min(B, len(Xb))).astype(np.float64)
+    freq = select_counts / np.maximum(trials, 1.0)
+    top_f = top_counts / max(B, 1)
+
+    # --- Build the DF once (shape identical to the slow path)
+    idx = pd.Index(range(1, max_lag + 1), name="lag")
+    out = pd.DataFrame(
+        {
+            "p_base": p0,
+            "reject_base_fdr": reject_fdr,
+            "freq": freq,
+            "stable": stable_flag,
+            "trials": trials,
+            "top_freq": top_f,
+            "n": n0.astype(np.float64),
+            "beta": beta0,
+            "t": t0,
+        },
+        index=idx,
+    )
+    return out
 
 
 def _auto_block_len(n: int) -> int:
@@ -558,7 +678,11 @@ def _resolve_lag_cfg(params: LagConfig, n: int) -> dict:
     }
 
 
-def select_lags(y: pd.Series, _debug: bool = False) -> list:
+def select_lags(
+    y: pd.Series,
+    engine: Literal["statsmodels", "numba"] = "statsmodels",
+    _debug: bool = False,
+) -> list:
     """
     Select time-series lags deemed significant by a bootstrap stability procedure combined with HAC-robust lag testing.
 
@@ -581,25 +705,49 @@ def select_lags(y: pd.Series, _debug: bool = False) -> list:
 
     r = _resolve_lag_cfg(params, n)
     # run the test
-    res = bootstrapped_significance(
-        y,
-        max_lag=r["max_lag"],
-        B=r["B"],
-        block_len=r["block_len"],
-        bandwidth=(
-            params["hacBandwidth"]
-            if params["hacBandwidth"] != "auto"
-            else r["bandwidth"]
-        ),
-        alpha=params["sigLevel"],
-        use_fdr_end=(params["selectionMethod"] == "fdrAdjusted"),
-        min_freq=params["stabilityFreq"] if params["requireStability"] else 0.0,
-        early_stop=params["earlyStop"],
-        b_min=params["minBootstrapSamples"],
-        check_every=params["stabilityCheckEvery"],
-        conf=params["stabilityConfidence"],
-        rng=rng,
-    )
+    if engine == "statsmodels":
+        res = bootstrapped_significance(
+            y,
+            max_lag=r["max_lag"],
+            B=r["B"],
+            block_len=r["block_len"],
+            bandwidth=(
+                params["hacBandwidth"]
+                if params["hacBandwidth"] != "auto"
+                else r["bandwidth"]
+            ),
+            alpha=params["sigLevel"],
+            use_fdr_end=(params["selectionMethod"] == "fdrAdjusted"),
+            min_freq=params["stabilityFreq"] if params["requireStability"] else 0.0,
+            early_stop=params["earlyStop"],
+            b_min=params["minBootstrapSamples"],
+            check_every=params["stabilityCheckEvery"],
+            conf=params["stabilityConfidence"],
+            rng=rng,
+        )
+
+    elif engine == "numba":
+        res = fast_bootstrapped_significance(
+            y,
+            max_lag=r["max_lag"],
+            B=r["B"],
+            block_len=r["block_len"],
+            bandwidth=(
+                params["hacBandwidth"]
+                if params["hacBandwidth"] != "auto"
+                else r["bandwidth"]
+            ),
+            alpha=params["sigLevel"],
+            use_fdr_end=(params["selectionMethod"] == "fdrAdjusted"),
+            min_freq=params["stabilityFreq"] if params["requireStability"] else 0.0,
+            early_stop=params["earlyStop"],
+            b_min=params["minBootstrapSamples"],
+            check_every=params["stabilityCheckEvery"],
+            conf=params["stabilityConfidence"],
+            rng=rng,
+        )
+    else:
+        raise ValueError(f"Unsupported engine: {engine}")
 
     # --- Build mask(s)
     if params["selectionMethod"] == "fdrAdjusted":

--- a/CandleNet/ticker/ticker.py
+++ b/CandleNet/ticker/ticker.py
@@ -28,6 +28,7 @@ class Ticker:
             self.data = _from_cache
             self.raw_data = None
             self.news: dict | None = None
+            self._log_ret: Optional[pd.Series] = None
             return
 
         if not _from_bulk_download:
@@ -94,6 +95,8 @@ class Ticker:
             hilo=hilo,
             sentiment=sentiment,
         )
+
+        self._log_ret = None
 
     def process_news(self) -> tuple[list[str], list[str], list[str]]:
         assert self.news is not None
@@ -168,6 +171,18 @@ class Ticker:
         if self._ticker is None:
             self._ticker = yf.Ticker(self.symbol)
         return self._ticker
+
+    @property
+    def log_returns(self) -> pd.Series:
+        if self._log_ret is None:
+            self._log_ret = np.log(self.price).diff(5).dropna()
+        return self._log_ret
+
+    @property
+    def log_ret_no_overlap(self) -> pd.Series:
+        if self._log_ret is None:
+            self._log_ret = np.log(self.price).diff(5).dropna()
+        return self._log_ret.iloc[::5]
 
 
 def _get_gspc() -> list:

--- a/CandleNet/utils/__init__.py
+++ b/CandleNet/utils/__init__.py
@@ -7,6 +7,7 @@ from .global_helpers import (
     uptri_abs_var,
     matrix_describe,
     str_encode,
+    demean,
     FRAME,
     SERIES,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "uptri_abs_var",
     "matrix_describe",
     "str_encode",
+    "demean",
     "FRAME",
     "SERIES",
 ]

--- a/CandleNet/utils/global_helpers.py
+++ b/CandleNet/utils/global_helpers.py
@@ -101,3 +101,11 @@ def str_encode(s: str) -> int:
     hash_hex = _hash_str(s)
     hash_int = int(hash_hex, 16)
     return hash_int & ((1 << 64) - 1)
+
+
+def demean(arr: SERIES) -> SERIES:
+    """Demean a 1D array or Series."""
+    assert arr.ndim == 1 and hasattr(arr, "mean"), (
+        "Input must be 1D with a mean method " "(e.g., pd.Series or 1D np.ndarray)"
+    )
+    return arr - arr.mean()

--- a/featureConfig.yaml
+++ b/featureConfig.yaml
@@ -8,10 +8,10 @@ index:
 # Autoregressive feature generation settings.
 lagSelection:
   minLagsSelected: 2  # Minimum number of lags to select
-  maxLagsSelected: auto         # [int, "auto"] Select based on results of lag significance tests. "auto" uses min(20, log2(n)+2)
+  maxLagsSelected: auto         # [int, "auto"] Select based on results of lag significance tests. "auto" uses min(5, maxLag)
   maxLag: 20  # Maximum lag to consider
   selectionMethod: fdrAdjusted  # [fdrAdjusted, rawPval]
-  sigLevel: 0.05
+  sigLevel: 0.1
 
   requireStability: true
   stabilityFreq: 0.25  # Proportion of bootstrap samples in which a lag must be significant to be included

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytest==8.4.2
 statsmodels==0.14.5
 scikit-learn==1.7.2
 seaborn==0.13.2
+numba==0.62.1


### PR DESCRIPTION
This pull request introduces a new, high-performance lag selection engine for time series analysis in the `CandleNet.autoreg.fastlag` module, leveraging Numba for vectorized computation. It adds the `vectorized_select_lags` method and supporting utilities, integrates the fast engine into existing lag selection workflows, and provides users with the option to choose between the original and fast (Numba-based) implementations. Additionally, the pull request extends CLI log partitioning functionality and improves code clarity in several places.

### Fast Lag Selection Engine

* Added the `CandleNet.autoreg.fastlag` module with a vectorized, Numba-accelerated lag selection engine, including `_ols_hac_beta_t_vectorized` for fast HAC-robust regression and `vectorized_select_lags` for efficient lag selection. [[1]](diffhunk://#diff-bcb2c2ca9aa8b665cee8a1d336317e6411e502ede027101f06bbfdab2c539618R1-R75) [[2]](diffhunk://#diff-e1aa3c1e25c1e22cca4f151a6ba7040d772b955711f21741ef70169a021ff00aR1-R363) [[3]](diffhunk://#diff-86c2536a286fb24f59d275b65099d2aac73cf1156f05fd80a1f1a806e2586cc9R1-R3)
* Integrated the fast engine into the main lag selection workflow by importing and exposing `vectorized_select_lags` and allowing `select_lags` to choose between `"statsmodels"` and `"numba"` engines via a parameter. [[1]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6L9-R9) [[2]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6L561-R685)
* Added `fast_bootstrapped_significance` as a drop-in replacement for bootstrapped significance testing, using the fast kernel for improved performance.

### CLI Log Partitioning

* Added the `by_caller` method to `LogSplitter` in `CLI_tools/partition_logs.py`, enabling log partitioning by caller, and updated CLI argument parsing and dispatch to support the new option. [[1]](diffhunk://#diff-768a2f86d0bbbd6c03cb831b09a79dd1d69d9c451f3945cac840e5ce9ad6ebe7R148-R175) [[2]](diffhunk://#diff-768a2f86d0bbbd6c03cb831b09a79dd1d69d9c451f3945cac840e5ce9ad6ebe7R206) [[3]](diffhunk://#diff-768a2f86d0bbbd6c03cb831b09a79dd1d69d9c451f3945cac840e5ce9ad6ebe7R217-R218)

### Code Quality and Documentation

* Improved docstrings and parameter documentation for lag selection, block bootstrap, and related utilities, clarifying usage and expected types. [[1]](diffhunk://#diff-e1aa3c1e25c1e22cca4f151a6ba7040d772b955711f21741ef70169a021ff00aR1-R363) [[2]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6L338-R342)
* Fixed minor typos and improved code clarity, such as correcting references to Newey-West/HAC and using `np.nanargmin` for top-rank selection. [[1]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6L338-R342) [[2]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6L421-R421)

---

**References:**  
[[1]](diffhunk://#diff-bcb2c2ca9aa8b665cee8a1d336317e6411e502ede027101f06bbfdab2c539618R1-R75) [[2]](diffhunk://#diff-e1aa3c1e25c1e22cca4f151a6ba7040d772b955711f21741ef70169a021ff00aR1-R363) [[3]](diffhunk://#diff-86c2536a286fb24f59d275b65099d2aac73cf1156f05fd80a1f1a806e2586cc9R1-R3) [[4]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6L9-R9) [[5]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6L561-R685) [[6]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6R482-R601) [[7]](diffhunk://#diff-768a2f86d0bbbd6c03cb831b09a79dd1d69d9c451f3945cac840e5ce9ad6ebe7R148-R175) [[8]](diffhunk://#diff-768a2f86d0bbbd6c03cb831b09a79dd1d69d9c451f3945cac840e5ce9ad6ebe7R206) [[9]](diffhunk://#diff-768a2f86d0bbbd6c03cb831b09a79dd1d69d9c451f3945cac840e5ce9ad6ebe7R217-R218) [[10]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6L338-R342) [[11]](diffhunk://#diff-d9dcdf365795ae39b4b75efad6751b7218ff29d7258dc727734c42a10a1ef1a6L421-R421)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: option to partition logs by caller into separate files.
  * Autoreg: numba-accelerated, vectorized lag-selection backend (public API) and fast bootstrap path; exposed vectorized_select_lags.
  * Ticker: cached log returns and a non‑overlapping variant.
  * Utilities: added and exported a demean helper.

* **Bug Fixes**
  * Improved robustness of top-lag selection during bootstrapping.

* **Configuration**
  * Increased significance level to 0.1; max-lags-selected heuristic now min(5, maxLag).

* **Dependencies**
  * Added numba (0.62.1).

* **Chores**
  * CI: switch to cached virtualenv and venv-based tooling activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->